### PR TITLE
remove padding equal signs from RFC4648 encoded result

### DIFF
--- a/lib/u2f.js
+++ b/lib/u2f.js
@@ -191,7 +191,8 @@ exports.finishAuthentication = function(challenge, deviceResponse, deviceRegistr
 
 var base64_to_RFC4648 = function(input) {
   // RFC 4648 uses '-' instead of '+', and '_' instead of '/'.
-  return input.replace(/\+/g, '-').replace(/\//g, '_');
+  // Also remove the padding '='
+  return input.replace(/\+/g, '-').replace(/\//g, '_').replace(/\=/g, '');
 }
 
 var pubKeyToDER = function(key) {


### PR DESCRIPTION
The websafe-base64 used in U2F seems to be without padding. e.g.

https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-javascript-api.html

My U2F token (HyperFIDO) choked on the authentication challenge with the following error if the keyHandle is padded:
{
    "errorCode": 1,
    "errorMessage": "device status code: 6700"
}
